### PR TITLE
Docs: agents + tools + refreshed getting started

### DIFF
--- a/docs/Agents/_category_.json
+++ b/docs/Agents/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Agents",
+  "position": 3
+}

--- a/docs/Agents/foundry.md
+++ b/docs/Agents/foundry.md
@@ -1,0 +1,106 @@
+---
+sidebar_label: Foundry Image
+---
+
+# Agent Foundry Image
+
+This document describes the **Agent Foundry image pattern** used to mint custom OpenClaw runtimes for secure, sandboxed deployments. It’s the public‑safe version of an internal README and intentionally omits sensitive paths, secrets, and client‑specific details.
+
+## Summary
+
+The proven approach is:
+
+1. **Build a custom image** on top of a known‑good OpenShell base image
+2. **Publish to a registry**
+3. **Create sandboxes from the registry image**
+4. **Apply explicit sandbox policy** (filesystem, process, network)
+
+> The registry flow is the reliable path. Local “build‑and‑stream” experiments are helpful for debugging but aren’t the preferred production deployment method.
+
+## What This Pattern Enables
+
+- Custom agent runtimes with a **bespoke tool belt**
+- **Secure sandbox execution** with explicit policy
+- Fast rollout to multiple nodes via registry tags
+- Safer iteration with **blue/green updates**
+
+## Image Composition
+
+The image is intentionally minimal:
+
+- built on top of the standard OpenShell OpenClaw base image
+- no custom OpenShell entrypoint
+- default shell for stable startup
+- runtime state stored under a sandbox workspace directory
+
+Tools are layered in as needed for each agent family. (Exact tool lists are project‑specific and not included here.)
+
+## Project Layout (Public‑Safe)
+
+```text
+client-agent-image/
+├── Dockerfile
+├── bootstrap-policy.yaml
+├── docker-compose.yml
+├── compose.gateway.yml
+├── compose.smoke.yml
+├── scripts/
+├── data/           # local runtime data (excluded from builds)
+└── secrets/        # excluded from builds
+```
+
+> Build contexts exclude local data and secrets by default.
+
+## Local Docker Workflow (Safe Overview)
+
+1. Build the image locally
+2. Smoke test with a shell
+3. Validate tool availability and runtime defaults
+
+Detailed commands are omitted here to avoid environment‑specific paths.
+
+## Registry Workflow (Preferred)
+
+1. Build the image locally
+2. Tag for the registry
+3. Push to the registry
+4. Create a sandbox from the registry image
+
+> If the registry image is private, the sandbox environment must have pull credentials.
+
+## Sandbox Policy Model
+
+- **Static policies** (filesystem/process/landlock) must be set at creation time
+- **Network policy** can be adjusted later for new hosts or protocols
+
+When static policy changes, recreate the sandbox from the updated image + policy.
+
+## Security Notes
+
+What’s safe:
+- Keep secrets **out of image layers**
+- Mount runtime credentials at deploy time
+- Lock down filesystem + network access explicitly
+
+What to avoid:
+- Baking API keys into image layers
+- Assuming registry push is safe if the image contains secrets
+
+## Troubleshooting (High Level)
+
+Common failure modes:
+- Registry pull errors (missing credentials or incorrect tag)
+- Policy mis‑configuration (network or process restrictions)
+- Runtime mismatch with the base OpenShell contract
+
+## Recommended Release Flow
+
+1. Update the Dockerfile
+2. Build and smoke test locally
+3. Push a new tagged registry image
+4. Create a fresh sandbox with the updated policy
+5. Iterate on network access if needed
+
+## Bottom Line
+
+This pattern establishes a reliable, secure way to mint **bespoke agent runtimes** and operate them across a distributed sandbox fleet.

--- a/docs/Agents/toolsmith.md
+++ b/docs/Agents/toolsmith.md
@@ -1,0 +1,102 @@
+---
+sidebar_label: Toolsmith
+---
+
+# Agent Toolsmith
+
+Agent Toolsmith is the internal product surface for **building, browsing, and operating tool-enabled agents**. This public‑safe overview shares the architecture and workflows without exposing private paths, internal identifiers, or registry tags.
+
+> Original README references have been normalized to remove environment‑specific paths and identifiers.
+
+## Technologies
+
+**Backend:** Bun + Hono
+
+**Frontend:** TypeScript + Vite + React
+
+## Quickstart (Public‑Safe)
+
+- Frontend: `cd frontend && pnpm install && pnpm dev`
+- Backend: `cd backend && bun install && bun dev`
+- TUI tools search: `cd backend && bun run smth -- tui:tools`
+- CLI help: `cd backend && bun run smth -- help`
+
+## CLI + TUI
+
+- Launch the terminal tools browser: `smth -- tui`
+- Search tools without the interactive TUI: `smth -- tools search --query gh --no-interactive`
+- Inspect a specific tool provider: `smth -- tools inspect gh`
+
+## Agent HUD
+
+- Fleet overview: `/agents`
+- Agent detail: `/agents/:agentId`
+- Backend support: `GET /agents` and `GET /agents/:agentId`
+- Data sources: local agent registry, channel status, model metadata, and session history
+
+## Tests
+
+- Frontend: `pnpm lint && pnpm test && pnpm build`
+- Backend: `bun test`
+
+## Docs
+
+- `Agents.md`
+- `frontend/APP_MAP.md`
+- `backend/APP_MAP.md`
+- `docs/CONTRACTS.md`
+
+## DevOps
+
+- GitHub
+- Docker
+
+## Control Plane Rollouts (Overview)
+
+The `smth` CLI is the canonical operator surface for control‑plane rollouts and blue/green sandbox cutovers.
+
+- Validate desired‑state fixtures: `smth -- control-plane validate`
+- View a control‑plane summary: `smth -- control-plane summary`
+- Inspect an agent: `smth -- control-plane inspect <agent-id>`
+- Create a re‑image rollout plan:
+  `smth -- control-plane rollout reimage --agent-id <agent-id> --target-revision <revision> --image <registry-image> --reason "Tool bundle refresh"`
+- Check rollout status:
+  `smth -- control-plane rollout status --agent-id <agent-id>`
+- Promote a validated rollout:
+  `smth -- control-plane rollout promote --agent-id <agent-id>`
+- Roll back to the previous slot:
+  `smth -- control-plane rollout rollback --agent-id <agent-id> --reason "Gateway validation failed"`
+
+## Blue/Green Cutover (High Level)
+
+Each managed agent has two deployment slots: **blue** and **green**.
+
+- Only one slot is active at a time
+- The inactive slot is the rebuild target for re‑image operations
+- The gateway owns the external channel identity and forwards traffic to the active slot
+- Validation happens on the inactive slot before cutover
+
+### Standard Re‑image Flow
+
+1. Pull the latest desired revision for the agent
+2. Resolve the active slot and choose the inactive slot
+3. Export handoff state from the active slot
+4. Rebuild the inactive slot from the new registry image
+5. Import handoff state and reapply bootstrap helpers
+6. Start the gateway and validate policy + tools
+7. Switch traffic to the rebuilt slot
+8. Drain the old slot and keep it as rollback
+9. Mark the rollout complete
+10. Clean up after the rollback window expires
+
+## Operational Notes
+
+- Durable business state should live outside the sandbox slots
+- Secrets are re‑injected from the secret manager, not copied between slots
+- Rollouts should be treated as a checkpointed state machine
+
+## Notes on Safety
+
+- Public docs intentionally omit internal paths and registry tags
+- Sample IDs are placeholders
+- Replace placeholders with your own environment‑specific values

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,372 +2,73 @@
 sidebar_position: 2
 ---
 
-# 🚀 Getting Started with Guardian AGI System
+# Getting Started
 
-Guardian is a distributed, multi-service AGI infrastructure designed for **autonomous, always-on orchestration** of agents, workflows, and advanced reasoning.  
-This guide provides an **overview of every major component** in the system, including how services interact, their purpose, and where to find more information. The system is comprised of a curated collection of open source software combined with custom code to create a self-sustaining, autonomous AGI system.
+Woodward Studio is where I build **enterprise‑grade, secure, managed AI agents** for real operations work. The focus right now is **agentic ops engineering**: custom tool belts, hardened sandbox policies, and fleet‑level management that makes frontier models safe to run in production.
 
----
-
-## 🐳 Containerization and Base Runtime
-
-### [Docker](../services/docker.md)
-Used to containerize and deploy most Guardian services.  
-- Runs Supabase, Neo4j, Qdrant, n8n, Ollama, and other infrastructure.
-- Enables reproducible, scalable deployments.
-
-Docs 👉 [docs.docker.com](https://docs.docker.com/)
+This site is the public, evolving reference for how I do it — what I’m building, how it works, and how you can adopt it (managed or self‑hosted).
 
 ---
 
-## 💬 LLM Interfaces
+## What I’m Building (Now)
 
-### [OpenWebUI](../services/openwebui.md)
-- Browser-based chat UI for interacting with Guardian’s LLMs.
-- Allows manual prompting and debugging of agents.
+**The Agents Initiative**
 
-Docs 👉 [docs.openwebui.com](https://docs.openwebui.com/)
+- **Custom agent images** baked with purpose‑built tool belts
+- **Secure sandbox deployment** with explicit filesystem, process, and network policy
+- **Managed ops**: blue/green updates, runbooks, and observability
+- **Frontier model integration** with hardened channels and tool boundaries
 
-### [Goose CLI](../services/goose-cli.md)
-- Command-line automation and migrations tool.
-- Used by Guardian agents for rapid infrastructure adjustments.
-- 40+ MCP Servers pre-configured.
-
-Docs 👉 [block.github.io/goose/docs](https://block.github.io/goose/docs/category/guides)
-
-### [LightRAG](../services/lightrag.md)
-- Lightweight retrieval-augmented generation service.
-- Powers fast graph-based context retrieval.
-
-Docs 👉 [github.com/HKUDS/LightRAG](https://github.com/HKUDS/LightRAG)
-
-### [OpenDia](../services/opendia.md)
-- The open alternative to Dia / Perplexity Comet
-- Connect your browser to AI models. No browser switching needed—works seamlessly with Chrome, Firefox, and any Chromium browser. Private, local-first & MCP focused.
-- (Browser Control MCP) OpenDia gives AI models 18 powerful browser tools
-
-Docs 👉 [github.com/aaronjmars/opendia](https://github.com/aaronjmars/opendia)
+> The last week of work has been about making OpenShell + OpenClaw + policy + tools + models + channels all play nicely — and then standardizing that into a repeatable factory.
 
 ---
 
-## 🖥️ Development Environment
+## How the Agent Factory Works
 
-### [Code-Server](../services/code-server.md) + [Continue](../services/continue.md)
-- Cloud-hosted VS Code IDE with LLM coding assistance.
-- Used by DevOps Agent and for manual intervention.
+1) **Design the agent** (tool belt + workflow)
+2) **Bake a custom image** (registry‑hosted)
+3) **Deploy in secure sandboxes** (policy enforced)
+4) **Operate and evolve** (blue/green updates)
 
-### [Guardian CLI](../services/guardian-cli.md)
-- Local command-line tool for managing Guardian services.
-- Scaffolds new agents, apps, and orchestrator scripts.
-
----
-
-## 🔄 Automation and Orchestration
-
-### [n8n](../services/n8n.md)
-- Workflow automation server.
-- Handles third-party integrations like Upwork, blog posting, Slack workflows.
-
-### [Guardian Engine (Orchestrator)](../services/orchestrator.md)
-- 24/7 background process.
-- Executes tasks and goals autonomously.
-- Connects to all micro-agents and MCPs.
-
-### [Guardian Controller](../services/guardian-controller.md)
-- High-level coordinator for task planning and orchestration.
-- Manages execution order and complex automation flows.
+This pattern supports both **managed hosting** and **self‑hosting** — everything is being built in public and documented here.
 
 ---
 
-## 🧠 LLM Runtime
+## Start Here (Docs)
 
-### [Ollama](../services/ollama.md)
-- Local LLM runtime for models like LLaMA 3 and CodeLLaMA.
-- Provides offline, private inference for Guardian.
+### Agent Systems
+- **Agent Foundry image pattern** → `/docs/Agents/foundry`
+- **Agent Toolsmith (operator CLI + control‑plane)** → `/docs/Agents/toolsmith`
 
-### [Ollama-Proxy](../services/ollama-proxy.md)
-- Middleware service between Guardian and Ollama.
-- Adds telemetry tracking, retries, and performance tuning.
-
----
-
-## 🏠 Smart Home Automation
-
-### [Home Assistant](../services/home-assistant.md)
-- Integrates IoT devices for Sentinel Agent.
-- Allows Guardian to perceive and act on real-world environmental data.
-
----
-
-## 📈 Observability Stack
-
-### [Grafana](../services/grafana.md)
-- Visualization dashboard for logs, metrics, and telemetry.
-
-### [Loki](../services/loki.md)
-- Centralized logging backend for Guardian and its agents.
-
-### [Prometheus](../services/prometheus.md)
-- Metrics scraper and time-series database.
-
-### [Tempo](../services/tempo.md)
-- Distributed tracing system for cross-service debugging.
-
-### [Uptime Kuma](../services/uptime-kuma.md)
-- Monitors service health and uptime for Guardian infrastructure.
+### CLI Tools (Public‑Safe)
+- **smth** (Toolsmith CLI) → `/docs/tools/smth`
+- **guardian** → `/docs/tools/guardian`
+- **subagent** → `/docs/tools/subagent`
+- **quickbooks** → `/docs/tools/quickbooks`
+- **graph-api** → `/docs/tools/graph-api`
+- **heygen** → `/docs/tools/heygen`
+- **linear-cli** → `/docs/tools/linear-cli`
+- **notion** → `/docs/tools/notion`
+- **obs-cli** → `/docs/tools/obs-cli`
 
 ---
 
-## 🔐 Networking and Cloud Access
+## Who This Is For
 
-### [Tailscale](../services/tailscale.md)
-- Zero-trust private mesh network.
-- Connects homelab, Raspberry Pi nodes, and Guardian servers.
-
-### [Cloudflare](../services/cloudflare.md)
-- Edge security and access management.
-- Protects all Guardian ingress points with service tokens.
-
-### [Netlify](../services/netlify.md)
-- Hosting for Guardian Dashboard and public-facing apps.
-
-### [Render](../services/render.md)
-- Cloud server hosting for Gateway and microservices.
+- Clients who want **secure, production‑grade agents**
+- Builders who want a **reference architecture** for agent ops
+- Peers curious about **how to operationalize frontier models safely**
 
 ---
 
-## 🔌 External Services
+## What You Can Do Next
 
-### [Slack](../services/slack.md)
-- Chat and collaboration platform.
-- Real-time notifications and integrations.
-
-### [Notion](../services/notion.md)
-- Knowledge base and document management.
-- Task and project management.
-
-### [GitHub](../services/github.md)
-- Source control and CI/CD for all Guardian repositories.
+- Explore the **Agent Foundry** docs to understand the image + policy pattern
+- Use **Toolsmith** to browse tools and operate rollouts
+- Follow along as new tool belts, policies, and demos ship
 
 ---
 
-## 🛡️ Guardian-Specific Services
+## Public + Open
 
-- [Guardian Server](../services/guardian-server.md): Core HTTP API.
-- [Guardian Gateway](../services/guardian-gateway.md): External ingress gateway for secure request routing and zero-trust access.
-- [Guardian Vision Service](../services/guardian-vision.md): Real-time computer vision.
-- [Guardian Codegen Service](../services/guardian-codegen.md): Dedicated code generation microservice.
-  * [AgentOS](https://buildermethods.com/agent-os)
-  * [RepoPrompt](https://repoprompt.com/docs#s=overview)
-  * [MicroAgent](https://www.builder.io/blog/micro-agent)
-  * [Refact](https://docs.refact.ai/introduction/quickstart/)
-- [Guardian Dashboard](../services/guardian-dashboard.md): Mission control UI.
-- [AgentFlow](../services/agentflow.md): Visual orchestration system for building, simulating, and executing complex agent flows.
-- [Memory.me](../services/memory-me.md): Centralized memory management service for Guardian, handling long-term storage, pruning, and semantic graph connections.
-- [Guardian Logical Reasoning Engine (LRE)](../services/logical-reasoning-engine.md): Advanced planning and inference engine.
-  * [Quantum Reasoning w/PennyLane](https://docs.pennylane.ai/en/stable/introduction/pennylane.html) 
-  * [Physics Reasoning w/Genesis](https://genesis-world.readthedocs.io/en/latest/user_guide/overview/what_is_genesis.html) Genesis is a physics platform designed for general purpose Robotics/Embodied AI/Physical AI applications
-  * [Math Reasoning w/Wolfram|Alpha LLM API](https://products.wolframalpha.com/llm-api/documentation)
-  * [Symbolic Reasoning w/Sympy](https://docs.sympy.org/latest/index.html)
-  * [Chemical Reasoning w/Chemlib](https://chemlib.readthedocs.io/en/latest/)
-  * [3D Simulation Reasoning w/Unity](https://docs.unity3d.com/Manual/Overview.html)
-- [Guardian Browser Extension](../services/guardian-browser-extension.md): Live web integrations.
-- [Guardian Open Source](../services/guardian-open-source.md): Public version of Guardian for community use.
-- [Booking Listener](../services/booking-listener.md): Automates booking system integrations.
-- [Aegis](../services/aegis.md): Security and audit microservice.
-
----
-
-## 🗄️ Database Layer
-
-### [Supabase](../databases/supabase.md) *(Relational)*
-- Postgres-based database.
-- Stores tasks, telemetry, analytics, and agent flows.
-
-### [Qdrant](../databases/qdrant.md) *(Vector)*
-- Vector DB for embeddings and semantic search.
-
-### [Neo4j](../databases/neo4j.md) *(Graph)*
-- Graph memory store for task causality and reasoning.
-
-### [TimescaleDB](../databases/timescaledb.md) *(Temporal)*
-- Time-series database for telemetry and system events.
-
-### [SpacetimeDB](../databases/spacetimedb.md) *(Spatial)*
-- Spatial database for future geo-context reasoning.
-
-### [SurrealDB](../databases/surrealdb.md) *(Multi-Model)*
-- Multi-model database supporting graph, key-value, and document modes.
-
----
-
-## ✅ Next Steps
-
-1. [Install Docker](../services/docker.md) and core infrastructure.
-2. Spin up [Supabase](../databases/supabase.md), [Qdrant](../databases/qdrant.md), and [Neo4j](../databases/neo4j.md).
-3. Launch [Guardian Server](../services/guardian-server.md) and [Guardian Engine](../services/orchestrator.md).
-4. Connect [OpenWebUI](../services/openwebui.md) or [Guardian Dashboard](../services/guardian-dashboard.md) for live control.
-5. Review each service’s documentation for configuration and troubleshooting.
-
----
-
-> **Tip:** Guardian is modular 🌱 — you can start with the minimal stack (Supabase + Guardian Server + Ollama) and add other services like Orchestrator, Observability, and Automation as needed.
-
-
-
----
-
-# Getting Started with WoodwardStudio
-
-This guide will walk you through installing, configuring, and using the `woodward-studio` development framework to build full-stack apps quickly and efficiently.
-
-Whether you're starting from scratch or plugging the package into an existing app, these are the steps to get up and running fast.
-
----
-
-## 📦 Install the Package
-
-Install the internal dev library via your monorepo or standalone app:
-
-```bash
-pnpm add woodward-studio
-```
-
-Make sure your app uses:
-- **React + TypeScript**
-- **Vite (or Rspack/Webpack)**
-- **MUI**
-- **Zustand**
-- **Supabase** (optional)
-
----
-
-## ⚙️ Initialize the API Client
-
-Your app should generate an `api.config.json` using the CLI:
-
-```bash
-woodward-studio api generate
-```
-
-Then wire up the API system:
-
-```ts
-import { generateStudioApi } from "woodward-studio";
-import apiConfig from "./api.config.json";
-import { supabase } from "./supabase";
-
-const { client, paths, queries } = generateStudioApi({
-  config: apiConfig,
-  env: {
-    baseURL: import.meta.env.VITE_HOSTNAME,
-    apiKey: import.meta.env.VITE_MASTER_API_KEY,
-  },
-  supabase,
-});
-```
-
-You can now use:
-```ts
-useStudioQuery(queries.query(paths => paths.users.getList))
-```
-
----
-
-## 🧰 Use the CLI
-
-The CLI includes scaffolding and utility commands:
-
-```bash
-woodward-studio create-app my-app
-woodward-studio create-component Button custom
-woodward-studio create-route dashboard /dashboard
-```
-
-Each command is modular and extendable — full templates coming soon.
-
----
-
-## 🧪 Dev Workflow
-
-Run Storybook or Docs locally:
-
-```bash
-pnpm --filter storybook dev
-pnpm --filter docs start
-```
-
-Build the library for publish:
-```bash
-pnpm --filter woodward-studio build
-```
-
-Publish to npm:
-```bash
-npm publish --access public
-```
-
----
-
-## 🧠 Next Steps
-
-- Explore [Components](./components)
-- See how [API Utilities](./api) work
-- Customize your [Theme](./theming)
-- Use [Hooks](./hooks) across apps
-
-You’re now ready to build with WoodwardStudio 🚀
-
-
-# Getting Started with Guardian AGI System 
-
-- Docker
-- OpenWebUI
-- Goose CLI
-- LightRAG
-- OpenDia
-- Code-Server + Continue
-- n8n
-- Ollama
-- Home Assistant
-- Flowise
-
-- Grafana
-- Loki
-- Prometheus
-- Tempo
-- Uptime Kuma
-
-- Tailscale
-- Cloudflare
-- Github
-- Netlify
-- Render
-
-- Guardian Server
-- Guardian Engine (Orchestrator)
-- Guardian Vision Service
-- Guardian Codegen Service
-- Guardian CLI
-- Guardian Controller
-- Guardian Dashboard
-- Guardian Logical Reasoning Engine (LRE)
-- Guardian Browser Extension
-- Guardian Gateway
-- Guardian Open Source
-- Ollama-Proxy
-- Booking-Listener
-- Aegis
-- Memory.me
-- AgentFlow
-
-- Supabase [Relational]
-- Qdrant [Vector]
-- Neo4j [Graph]
-- TimescaleDB [Temporal]
-- SpacetimeDB [Spatial]
-- SurrealDB [Multi-Model]
-
-- Github
-- Notion
-- Slack
+Everything here is public by design. As the system evolves, the docs will keep up — including the parts that work, the things that broke, and the patterns that scaled.

--- a/docs/tools/_category_.json
+++ b/docs/tools/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Tools",
+  "position": 4
+}

--- a/docs/tools/graph-api.md
+++ b/docs/tools/graph-api.md
@@ -1,0 +1,48 @@
+---
+sidebar_label: graph-api
+---
+
+# graph-api
+
+Minimal CLI for authenticating with **Microsoft Graph** and running useful delegated‑user requests.
+
+## What it supports
+
+- OAuth 2.0 authorization code flow with PKCE
+- Local token storage + refresh
+- `me` profile, OneDrive root, starter mail listing
+- User lookup by id/UPN
+- Raw request escape hatch
+
+## Install
+
+```bash
+npm link
+graph-api help
+```
+
+## Authenticate
+
+```bash
+export GRAPH_CLIENT_ID=...
+export GRAPH_TENANT=common
+export GRAPH_REDIRECT_URI=http://127.0.0.1:8787/callback
+export GRAPH_SCOPES="openid profile offline_access User.Read Files.Read Mail.Read"
+
+graph-api auth login
+```
+
+## Common commands
+
+```bash
+graph-api me
+graph-api me drive
+graph-api me messages --limit 10
+graph-api users get --id user@contoso.com
+graph-api request GET /me
+```
+
+## Notes
+
+- Prefer the **Mobile/Desktop** redirect URI for public‑client auth
+- `request` targets `https://graph.microsoft.com/v1.0` by default

--- a/docs/tools/guardian.md
+++ b/docs/tools/guardian.md
@@ -1,0 +1,61 @@
+---
+sidebar_label: guardian
+---
+
+# guardian
+
+CLI bridge for interacting with a Guardian server API, plus local tool registry and MCP helpers.
+
+## What it supports
+
+- Login + config management
+- Generic REST calls
+- Agent and run shortcuts
+- Tool registry management
+- MCP server registry + calls
+- Skeleton‑key tool resolution (`skey`)
+
+## Install
+
+```bash
+npm link
+guardian --help
+```
+
+## Quick start
+
+```bash
+guardian login --base-url https://guardian.example.com --token <token>
+guardian ping
+guardian get /api/agents
+guardian post /api/runs --body-json '{"agentId":"agent_123","input":"run this"}'
+```
+
+## Tool registry
+
+```bash
+guardian tools init
+guardian tools add --surface cli --name notion --command notion --description "Notion CLI bridge"
+guardian tools search "create a notion page"
+```
+
+## Skeleton key
+
+```bash
+guardian skey run "create notion page with this data" --tool-id cli:notion --confirm
+guardian skey confirm <call-signature-id>
+```
+
+## MCP helpers
+
+```bash
+guardian mcp add filesystem --cmd npx --arg -y --arg @modelcontextprotocol/server-filesystem --arg <path>
+guardian mcp tools filesystem
+guardian mcp call filesystem read_file --input-json '{"path":"<file>"}'
+```
+
+## Notes
+
+- Use `guardian api <METHOD> </path>` for any endpoint
+- `skey` resolves tools **locally**, not via the server
+- Replace placeholders with your environment values

--- a/docs/tools/heygen.md
+++ b/docs/tools/heygen.md
@@ -1,0 +1,44 @@
+---
+sidebar_label: heygen
+---
+
+# heygen
+
+CLI for the **HeyGen API**: authenticate, list avatars/voices, and create videos via Video Agent.
+
+## Install
+
+```bash
+npm link
+heygen help
+```
+
+## Authenticate
+
+```bash
+heygen auth login --api-key "$HEYGEN_API_KEY"
+# or
+printenv HEYGEN_API_KEY | heygen auth login --api-key-stdin
+```
+
+## Common commands
+
+```bash
+heygen auth status --verify
+heygen whoami
+heygen avatars list
+heygen voices list
+heygen video-agent create --prompt "Create a 20-second welcome video"
+heygen video status <video_id>
+```
+
+## Raw requests
+
+```bash
+heygen request GET /v1/video.list
+```
+
+## Notes
+
+- Default API base is `https://api.heygen.com`
+- `HEYGEN_API_KEY` overrides stored config for the current command

--- a/docs/tools/linear-cli.md
+++ b/docs/tools/linear-cli.md
@@ -1,0 +1,46 @@
+---
+sidebar_label: linear-cli
+---
+
+# linear-cli
+
+CLI for syncing an **Obsidian markdown board** into Linear.
+
+## What it supports
+
+- Personal API key auth
+- Team/project discovery
+- Parse a markdown board
+- Plan + push missing issues into a project
+
+## Install
+
+```bash
+npm link
+linear-cli --help
+```
+
+## Authenticate
+
+```bash
+linear-cli auth login --api-key lin_api_xxx
+linear-cli auth status
+```
+
+## Parse a board
+
+```bash
+linear-cli board parse --file "<path-to-board.md>"
+```
+
+## Plan + push
+
+```bash
+linear-cli sync plan --file "<path-to-board.md>" --team ENG --project "Agent Project"
+linear-cli sync push --file "<path-to-board.md>" --team ENG --project "Agent Project"
+```
+
+## Notes
+
+- Matching is title‑based (no bidirectional sync yet)
+- Use `--state-map` when your headings don’t match Linear states

--- a/docs/tools/notion.md
+++ b/docs/tools/notion.md
@@ -1,0 +1,45 @@
+---
+sidebar_label: notion
+---
+
+# notion
+
+Practical CLI for common **Notion API** workflows.
+
+## What it supports
+
+- One‑time login with local token persistence
+- Search
+- Read/create/update pages
+- Query data sources
+- List/append block children
+- Generic API escape hatch
+
+## Install
+
+```bash
+npm link
+notion --help
+```
+
+## Authenticate
+
+```bash
+notion login
+```
+
+## Common usage
+
+```bash
+notion whoami
+notion search "roadmap"
+notion page get <page-id>
+notion page create --parent-page <page-id> --title "CLI-created page" --content "hello"
+notion data-source query <data-source-id> --page-size 10
+notion blocks append <block-id> --text "added from cli"
+```
+
+## Notes
+
+- Default Notion version header can be overridden with `--notion-version`
+- Use `notion api ...` for any raw endpoint

--- a/docs/tools/obs-cli.md
+++ b/docs/tools/obs-cli.md
@@ -1,0 +1,52 @@
+---
+sidebar_label: obs-cli
+---
+
+# obs-cli
+
+CLI for controlling **OBS Studio** over WebSocket (via obs-websocket-js).
+
+## Requirements
+
+- OBS Studio with WebSocket enabled
+- Node.js 18+
+- WebSocket password if auth is enabled
+
+## Install
+
+```bash
+npm link
+obs-cli help
+```
+
+## Connect
+
+```bash
+obs-cli --url ws://127.0.0.1:4455 --password <password> status
+```
+
+Or via env vars:
+
+```bash
+export OBS_URL=ws://127.0.0.1:4455
+export OBS_PASSWORD=<password>
+obs-cli scenes
+```
+
+## Common commands
+
+```bash
+obs-cli status
+obs-cli scenes
+obs-cli scene set "Starting Soon"
+obs-cli stream start
+obs-cli stream stop
+obs-cli record start
+obs-cli record stop
+obs-cli screenshot save "Camera" /tmp/camera.png
+```
+
+## Notes
+
+- `call` is the escape hatch for any OBS request
+- If OBS is not running or WebSocket is off, commands will fail on connect

--- a/docs/tools/quickbooks.md
+++ b/docs/tools/quickbooks.md
@@ -1,0 +1,66 @@
+---
+sidebar_label: quickbooks
+---
+
+# quickbooks
+
+Minimal CLI for authenticating with **QuickBooks Online** and running common accounting operations from the terminal.
+
+## What it supports
+
+- OAuth 2.0 login and token refresh
+- Company info lookup
+- Customers, vendors, accounts, items
+- Invoices and bills
+- Reports
+- Raw query + raw request escape hatches
+
+## Install
+
+```bash
+npm link
+quickbooks help
+```
+
+## Authenticate
+
+```bash
+export QBO_CLIENT_ID=...
+export QBO_CLIENT_SECRET=...
+export QBO_ENVIRONMENT=sandbox
+export QBO_REDIRECT_URI=http://127.0.0.1:4545/callback
+
+quickbooks auth login
+```
+
+## Common commands
+
+```bash
+quickbooks auth status
+quickbooks company info
+quickbooks customers list --limit 20
+quickbooks vendors list --limit 20
+quickbooks invoices list --limit 20
+quickbooks bills list --limit 20
+quickbooks reports profit-and-loss --date-macro ThisMonth
+```
+
+## Examples
+
+Create a customer:
+
+```bash
+quickbooks customers create --display-name "Acme LLC" --email ops@acme.com
+```
+
+Run a raw query:
+
+```bash
+quickbooks query "select * from Customer maxresults 10"
+```
+
+## Notes
+
+- Targets **QuickBooks Online Accounting** only
+- Access tokens refresh automatically when possible
+- `request` expects a path under `/v3/company/<realmId>`

--- a/docs/tools/smth.md
+++ b/docs/tools/smth.md
@@ -1,0 +1,56 @@
+---
+sidebar_label: smth (Toolsmith CLI)
+---
+
+# smth (Agent Toolsmith CLI)
+
+**smth** is the operator‑grade CLI for Agent Toolsmith. It powers tool discovery, inspection, and control‑plane rollouts for managed agents.
+
+## What it does
+
+- Search and inspect available tools
+- Operate control‑plane rollouts (blue/green)
+- Inspect agent states and rollout status
+- Provide a TUI for browsing tools
+
+## Install
+
+Run from the Toolsmith backend project:
+
+```bash
+bun install
+bun run smth -- help
+```
+
+Optional global link:
+
+```bash
+bun link
+smth -- help
+```
+
+## Tooling commands
+
+```bash
+smth -- tui
+smth -- tools search --query gh --no-interactive
+smth -- tools inspect gh
+```
+
+## Control‑plane rollouts (high level)
+
+```bash
+smth -- control-plane validate
+smth -- control-plane summary
+smth -- control-plane inspect <agent-id>
+smth -- control-plane rollout reimage --agent-id <agent-id> --target-revision <rev> --image <registry-image>
+smth -- control-plane rollout status --agent-id <agent-id>
+smth -- control-plane rollout promote --agent-id <agent-id>
+smth -- control-plane rollout rollback --agent-id <agent-id>
+```
+
+## Notes
+
+- Intended for agent fleet operations
+- Works best when paired with your control‑plane desired‑state registry
+- Replace placeholders with your environment‑specific IDs

--- a/docs/tools/subagent.md
+++ b/docs/tools/subagent.md
@@ -1,0 +1,46 @@
+---
+sidebar_label: subagent
+---
+
+# subagent
+
+CLI for dispatching tasks to local sub‑agent runtimes with deterministic routing.
+
+## What it supports
+
+- Agent registry + routing rules
+- Background execution + fan‑out
+- Stats and selection analytics
+- Dry‑run command previews
+
+## Install
+
+```bash
+npm link
+subagent --help
+```
+
+## Quick start
+
+```bash
+subagent config init
+subagent agents
+subagent route "review this repo for regressions" --review
+subagent run "implement a new CLI command" --cwd <path>
+subagent batch "compare delegation strategies" --agent claude --agent gemini
+subagent stats
+```
+
+## Commands
+
+```bash
+subagent config set-default <agent>
+subagent route "<task>" [--code|--review|--plan|--research] [--background]
+subagent run "<task>" [--agent <name>] [--cwd <dir>] [--background] [--dry-run]
+subagent batch "<task>" --agent <name>... [--top 2] [--dry-run]
+```
+
+## Notes
+
+- Best for local routing + execution; use a queue/API for durable remote jobs
+- Config and run logs live under `~/.config/subagent-cli/`


### PR DESCRIPTION
## Summary\n- Refresh Getting Started for the Agents Initiative\n- Add Agents docs (Foundry + Toolsmith)\n- Add Tools docs (smth, guardian, subagent, quickbooks, graph-api, heygen, linear, notion, obs-cli)\n- Add sidebar categories for Agents + Tools\n\n## Notes\n- All docs are public-safe (no local paths or secrets)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Agents docs including Agent Foundry patterns and Agent Toolsmith operator guide
  * Added Tools docs with CLI references for Graph API, Guardian, HeyGen, Linear, Notion, OBS, QuickBooks, smth (Toolsmith), and Subagent
  * Revised Getting Started to introduce enterprise-grade managed AI agents and the Agent Factory workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->