### PR TITLE
docs: add generic Reddit monitoring workflow guides

### DIFF
--- a/docs/Guides/RedditManualReviewTemplate.md
+++ b/docs/Guides/RedditManualReviewTemplate.md
@@ -1,0 +1,233 @@
+# Reddit Manual Review Template
+
+## Overview
+
+This guide provides a reusable template for manually reviewing and capturing Reddit thread content when automated extraction is incomplete, unreliable, or blocked.
+
+It is intended to complement a Reddit discovery and prioritization workflow by giving reviewers a consistent way to collect thread context and comment text for later analysis.
+
+Typical downstream uses include:
+
+- sentiment analysis
+- topic labeling
+- trend review
+- qualitative research
+- competitor or market monitoring
+
+## When To Use This Template
+
+Use a manual review template when:
+
+- search discovery has already identified promising Reddit threads
+- automated scraping recovered only partial metadata
+- browser automation is blocked by security checks or anti-bot protections
+- the final step requires reliable human judgment anyway
+
+## Review Goals
+
+A good manual Reddit review should answer:
+
+- Is this thread actually relevant to the target keyword or topic?
+- What is the overall tone of the discussion?
+- What specific claims, themes, or complaints appear repeatedly?
+- Which comments are most useful for later analysis?
+- Is the thread strong enough to keep in the monitoring dataset?
+
+## Recommended Review Process
+
+1. Open the shortlisted Reddit thread in a real logged-in browser session.
+2. Confirm that the thread is actually relevant.
+3. Record basic thread metadata.
+4. Capture the most useful visible comments.
+5. Add reviewer notes and a relevance rating.
+6. Optionally label sentiment, topic, or risk.
+
+## Suggested Fields
+
+Use the following fields in a CSV, spreadsheet, database, or markdown note.
+
+### Core thread fields
+
+- keyword_or_topic
+- thread_url
+- thread_title
+- subreddit
+- thread_author
+- thread_date
+- comment_count_label
+- review_date
+- reviewer
+
+### Relevance and triage fields
+
+- relevance_rating
+- confidence_rating
+- keep_for_analysis
+- reason_kept
+- reason_discarded
+
+### Content summary fields
+
+- thread_summary
+- main_themes
+- repeated_phrases
+- notable_claims
+- notable_entities
+
+### Sentiment fields
+
+- overall_sentiment
+- sentiment_confidence
+- sentiment_notes
+
+### Comment capture fields
+
+- comment_1_author
+- comment_1_text
+- comment_2_author
+- comment_2_text
+- comment_3_author
+- comment_3_text
+- comment_4_author
+- comment_4_text
+- comment_5_author
+- comment_5_text
+
+### Optional operational fields
+
+- source_query
+- source_variant
+- source_run_id
+- needs_follow_up
+- follow_up_notes
+
+## Suggested Ratings
+
+### Relevance rating
+
+Use a simple 1 to 5 scale:
+
+- 1 = barely related
+- 2 = weakly related
+- 3 = somewhat relevant
+- 4 = clearly relevant
+- 5 = highly relevant and valuable
+
+### Confidence rating
+
+Use a simple 1 to 5 scale:
+
+- 1 = low confidence in interpretation
+- 2 = somewhat uncertain
+- 3 = moderate confidence
+- 4 = strong confidence
+- 5 = very high confidence
+
+### Overall sentiment
+
+Use a consistent label set such as:
+
+- very_negative
+- negative
+- mixed_negative
+- neutral
+- mixed_positive
+- positive
+- very_positive
+
+Choose one stable label system and keep it consistent across reviews.
+
+## Comment Selection Guidance
+
+Do not try to capture every comment.
+
+Instead, capture comments that are:
+
+- directly relevant to the target topic
+- representative of the thread’s overall tone
+- unusually specific or informative
+- repeated in substance across multiple users
+- useful for future sentiment or thematic analysis
+
+Try to avoid over-weighting:
+
+- jokes with no informational value
+- off-topic replies
+- low-context fragments
+- duplicate or near-duplicate comments
+
+## Suggested Review Heuristics
+
+When reading a thread, look for:
+
+- firsthand experience
+- recurring complaints or praise
+- operational details
+- product or service issues
+- employee or customer sentiment
+- timeline clues
+- market or competitor comparisons
+
+These often matter more than raw comment volume.
+
+## Minimal CSV Example
+
+A lightweight CSV can start with these columns:
+
+```text
+keyword_or_topic,thread_url,thread_title,subreddit,relevance_rating,overall_sentiment,thread_summary,comment_1_text,comment_2_text,comment_3_text,reviewer,review_date
+```
+
+## Expanded CSV Example
+
+For a richer workflow, use something like:
+
+```text
+keyword_or_topic,thread_url,thread_title,subreddit,thread_author,thread_date,comment_count_label,reviewer,review_date,relevance_rating,confidence_rating,keep_for_analysis,overall_sentiment,sentiment_confidence,thread_summary,main_themes,repeated_phrases,notable_claims,notable_entities,comment_1_author,comment_1_text,comment_2_author,comment_2_text,comment_3_author,comment_3_text,needs_follow_up,follow_up_notes
+```
+
+## Review Tips
+
+- Keep summaries short and factual.
+- Separate observation from interpretation.
+- If a claim looks important but uncertain, flag it instead of overstating it.
+- Use the same sentiment labels and scales every time.
+- Capture only enough comments to support later analysis.
+- If the thread is weak, discard it quickly and move on.
+
+## Recommended Workflow Pairing
+
+This template works best after a discovery pipeline has already done the following:
+
+- found Reddit URLs related to a keyword set
+- de-duplicated links
+- shortlisted promising threads
+- recovered basic thread metadata
+
+That way, manual review is only used on the highest-value threads.
+
+## Output Recommendation
+
+Store manual review outputs in a location that is easy to reuse later for:
+
+- sentiment analysis
+- reporting
+- qualitative coding
+- future monitoring runs
+
+Good options include:
+
+- CSV
+- spreadsheet
+- database table
+- markdown review files
+
+## Summary
+
+A manual Reddit review template is the practical fallback when the automated pipeline can find the right threads but cannot reliably extract full rendered comment text.
+
+Used correctly, it lets you:
+
+- preserve the value of automated discovery
+- collect the most important text reliably
+- create high-quality inputs for later sentiment analysis or research

--- a/docs/Guides/RedditMentionMonitoringWorkflow.md
+++ b/docs/Guides/RedditMentionMonitoringWorkflow.md
@@ -1,0 +1,356 @@
+# Reddit Mention Monitoring Workflow
+
+## Overview
+
+This guide describes a generic workflow for discovering, prioritizing, and reviewing Reddit discussions related to any set of target keywords.
+
+The workflow is designed for cases where you want to:
+
+- start from a set of keywords, brands, companies, topics, or entities
+- discover relevant discussion across the web
+- isolate Reddit-specific results
+- shortlist the most promising Reddit threads
+- collect thread context for later research, classification, or sentiment analysis
+
+This guide intentionally avoids sensitive, environment-specific, and session-specific details so it can be reused as a general reference.
+
+## What This Workflow Is For
+
+Use this workflow when you need to:
+
+- discover Reddit discussions related to a topic or keyword set
+- monitor competitor or brand mentions
+- find employee, customer, or community discussion
+- build a shortlist of Reddit threads for manual review
+- prepare text inputs for later sentiment analysis or qualitative review
+
+## High-Level Architecture
+
+This workflow works best as a layered pipeline:
+
+1. keyword seeding
+2. search discovery
+3. Reddit result filtering
+4. URL de-duplication
+5. thread prioritization
+6. metadata extraction
+7. optional rendered-page extraction
+8. manual or semi-manual review
+9. downstream sentiment analysis or classification
+
+The key design principle is:
+
+- use search tools for broad discovery
+- use Reddit-specific tools for follow-up extraction
+- use browser automation only when simpler extraction is not enough
+- keep a manual fallback because Reddit may block automated rendering
+
+## Recommended Tooling Pattern
+
+### Search discovery layer
+
+Use a web search tool or API that can:
+
+- search by keyword
+- constrain results to `reddit.com`
+- return structured results
+- support result export to JSON or CSV
+
+This layer is for discovering candidate Reddit URLs.
+
+### Reddit follow-up layer
+
+Use a Reddit-specific CLI, scraper, or parser that can:
+
+- fetch subreddit pages
+- fetch thread URLs
+- extract post titles and metadata
+- count or estimate thread activity
+
+This layer is for validating and prioritizing Reddit targets.
+
+### Browser layer
+
+Use browser automation only when needed to:
+
+- inspect rendered pages
+- recover visible text that simple scraping misses
+- validate page content manually or semi-manually
+
+This layer is the least reliable because Reddit may apply anti-bot protections.
+
+## Workflow Steps
+
+## Step 1. Define your seed keywords
+
+Start with a seed list of targets such as:
+
+- company names
+- product names
+- brand names
+- topic phrases
+- competitor names
+- community terms
+
+Keep the initial list focused.
+
+A good first pass is usually better than an exhaustive query explosion.
+
+## Step 2. Create first-pass query variants
+
+For each seed keyword, create a small number of practical query variants.
+
+A common first-pass set is:
+
+- exact keyword
+- exact keyword + `reddit`
+- exact keyword + a context term such as `employee`, `review`, `customer`, or `discussion`
+
+You can later add second-pass variants for stronger topics, such as:
+
+- `pay`
+- `layoffs`
+- `driver`
+- `support`
+- `pricing`
+- `warehouse`
+- `sales`
+- `union`
+- `review`
+
+The idea is to begin broad and only expand where the first-pass results are promising.
+
+## Step 3. Run discovery searches
+
+Run the first-pass queries through your search/discovery tool.
+
+Recommended behaviors:
+
+- constrain to `reddit.com` when possible
+- request structured output
+- store raw responses
+- store a summarized query log
+
+For each query, capture:
+
+- query text
+- query variant type
+- timestamp or run identifier
+- result count
+- sample titles
+- sample URLs
+- raw output location
+
+## Step 4. De-duplicate Reddit URLs
+
+Search discovery will often produce repeated links across query variants.
+
+Build a de-duplicated Reddit URL list that contains at minimum:
+
+- source keyword
+- query variant
+- result title
+- result URL
+- optional source label
+
+This de-duplicated URL set becomes the core handoff point between discovery and extraction.
+
+## Step 5. Rank and shortlist relevant threads
+
+Not every discovered Reddit URL is worth deeper review.
+
+Prioritize threads that appear to have:
+
+- direct keyword relevance
+- higher discussion activity
+- likely firsthand experience
+- strong operational, customer, employee, or market context
+- clearer signal than broad news reposts or weak keyword collisions
+
+Useful prioritization signals include:
+
+- thread title relevance
+- subreddit relevance
+- comment-count labels
+- likely user intent
+- repeated appearance across multiple queries
+
+The output of this step should be a focused shortlist of Reddit threads for deeper review.
+
+## Step 6. Extract thread metadata
+
+For each shortlisted thread, extract as much reliable metadata as possible.
+
+Useful fields include:
+
+- thread title
+- thread URL
+- author
+- subreddit
+- comment-count label
+- post timestamp if available
+- any available preview text
+
+This stage is often enough to support ranking and triage even if full comment extraction is not yet available.
+
+## Step 7. Attempt deeper thread extraction if needed
+
+If your Reddit extraction layer supports it, try to recover:
+
+- top-level comment text
+- comment authors
+- thread body text
+- rendered text from the page
+
+Be aware that this is often where Reddit becomes difficult.
+
+Common issues include:
+
+- partial HTML mismatch between old and modern Reddit views
+- incomplete comment extraction from lightweight scrapers
+- anti-bot checks in browser automation
+- rendered pages blocked behind challenge or security screens
+
+Because of that, deeper extraction should be treated as optional and best-effort.
+
+## Step 8. Use a manual or semi-manual fallback
+
+When browser automation is blocked or comment extraction is incomplete, use a manual review layer.
+
+This means:
+
+- open the top shortlisted Reddit threads in a real logged-in browser session
+- capture the most relevant visible comments
+- store the comments in a structured review sheet
+- attach notes for later analysis
+
+This is often the most reliable final step when Reddit blocks automated rendering.
+
+## Recommended Data Outputs
+
+A practical workflow should produce these artifacts:
+
+### 1. Query summary CSV
+
+One row per discovery query, including:
+
+- seed keyword
+- query variant
+- query text
+- hit count
+- sample titles
+- sample URLs
+- raw file path
+
+### 2. De-duplicated Reddit URL CSV
+
+One row per unique Reddit URL, including:
+
+- keyword
+- query variant
+- title
+- URL
+- source label
+
+### 3. Focused thread review CSV or JSON
+
+One row per shortlisted thread, including:
+
+- keyword or entity
+- thread URL
+- title
+- subreddit
+- author
+- comment-count label
+- notes
+
+### 4. Manual capture sheet
+
+Used when rendered extraction is blocked.
+
+Suggested fields:
+
+- keyword or entity
+- thread URL
+- thread title
+- subreddit
+- captured comments
+- reviewer notes
+- sentiment label later
+- confidence or relevance rating
+
+## Operating Model Recommendation
+
+The most practical operating model is a two-layer process.
+
+### Automated layer
+
+Use automation for:
+
+- keyword discovery
+- Reddit result collection
+- URL de-duplication
+- shortlist generation
+- metadata extraction
+
+### Manual or semi-manual layer
+
+Use manual review for:
+
+- final comment capture
+- validation of ambiguous threads
+- collecting text for sentiment analysis
+- quality control
+
+This balance keeps the workflow efficient while acknowledging that Reddit may block the deepest layer of automation.
+
+## What This Workflow Does Well
+
+This workflow is especially good at:
+
+- finding Reddit threads related to a keyword set
+- reducing a broad search space into a focused shortlist
+- identifying strong research targets quickly
+- producing structured artifacts for review and analysis
+
+## Known Limitations
+
+This workflow may struggle with:
+
+- reliable full comment extraction at scale
+- pages protected by anti-bot systems
+- session-sensitive or challenge-gated Reddit views
+- browser automation paths that are flagged by Reddit security systems
+
+For that reason, the workflow should always include a manual fallback plan.
+
+## Recommended Next Improvements
+
+If you want to improve this workflow over time, useful next additions include:
+
+- a reusable manual review template
+- thread scoring rules
+- sentiment-ready export formatting
+- automated tagging by topic or theme
+- a review queue for repeated monitoring runs
+- a persistent datastore for tracking thread history across runs
+
+## Summary
+
+This workflow is best understood as a discovery and prioritization pipeline first, and a full content extraction pipeline second.
+
+It is reliable for:
+
+- finding relevant Reddit discussions
+- prioritizing the best threads
+- organizing artifacts for review
+
+It is less reliable for:
+
+- fully automated rendered comment extraction at scale
+
+The recommended operating model is therefore:
+
+- automate discovery and prioritization
+- use manual or semi-manual review for the final text capture step
+- then run sentiment analysis or other downstream analysis on the captured content


### PR DESCRIPTION
## Summary
- add a generic Reddit mention monitoring workflow guide
- add a companion manual review template guide
- remove session-specific and sensitive details so the docs are reusable

## Notes
These docs describe a general-purpose workflow for discovery, prioritization, and manual review of Reddit threads for later analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added manual review template guide for Reddit thread context capture with structured fields for metadata, relevance ratings, content summaries, and sentiment labels.
  * Added Reddit mention monitoring workflow guide detailing a layered pipeline approach spanning keyword discovery, thread ranking, metadata extraction, and manual fallback procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->